### PR TITLE
seo: add meta descriptions to all 25 docs pages

### DIFF
--- a/docs/ai-agent.md
+++ b/docs/ai-agent.md
@@ -1,3 +1,7 @@
+---
+description: Step-by-step guide to set up Wopee.io. Create a project, generate tests automatically, and run your first autonomous test in minutes.
+---
+
 # 🤖 Getting started
 
 ## 1. Login to [Wopee Commander](https://cmd.wopee.io)

--- a/docs/concepts/analysis-inputs.md
+++ b/docs/concepts/analysis-inputs.md
@@ -1,3 +1,7 @@
+---
+description: Feed Jira stories, Figma designs, or app crawl data into Wopee.io to generate higher-quality test cases with richer context.
+---
+
 # Analysis - Inputs
 
 First go to strategy for test analysis is to use our AI Testing Agent to analyze the application and generate test cases. Apart from crawling, you can also use Jira stories, Figma designs, or any other artifact to generate test cases. Actually, this is a more efficient way to generate test cases, because the AI Testing Agent can use only information from your crawling instruction / prompt and context from collected screenshots and HTML.

--- a/docs/concepts/analysis-process.md
+++ b/docs/concepts/analysis-process.md
@@ -1,3 +1,7 @@
+---
+description: How Wopee.io analyzes your web app to generate automated tests. Configure crawling, review scenarios, and export deterministic Playwright code.
+---
+
 # Analysis Process
 
 The analysis process transforms your application into a set of actionable, automated tests by systematically exploring its features, identifying user journeys, and generating reliable test cases. This ensures your app is thoroughly understood and tested, while giving you full control to guide and refine each step for maximum relevance and coverage.

--- a/docs/concepts/pom-login-example.md
+++ b/docs/concepts/pom-login-example.md
@@ -1,3 +1,7 @@
+---
+description: Build a reusable Page Object Model login module for Wopee.io. Register it once and reference it across multiple test scenarios without re-analysis.
+---
+
 # POM: Reusable Login Module
 
 On this example we will create a robust, reusable login module that Wopee.io can reference without re-analysis. This guide shows you how to build, register, and use login components efficiently.

--- a/docs/concepts/prompting-guidelines.md
+++ b/docs/concepts/prompting-guidelines.md
@@ -1,3 +1,7 @@
+---
+description: Best practices for writing effective prompts in Wopee.io. Structure goals, scope, and constraints to generate high-quality automated tests.
+---
+
 # Prompting Guidelines - Good Practices
 
 Master the art of writing effective prompts for Wopee.io to generate high-quality tests and documentation.

--- a/docs/concepts/tools-and-assertions.md
+++ b/docs/concepts/tools-and-assertions.md
@@ -1,5 +1,6 @@
 ---
 title: Tools & Assertions
+description: How Wopee.io agents interact with your app using click, type, select tools and validate outcomes with assertions. Generates plain Playwright code.
 ---
 
 # Tools & Assertions (Wopee.io)

--- a/docs/cypress/01-getting-started.md
+++ b/docs/cypress/01-getting-started.md
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: Get started with Wopee.io visual testing for Cypress. Clone the template project or install the plugin into your existing Cypress setup.
 ---
 
 ## Getting started

--- a/docs/cypress/02-template-project.md
+++ b/docs/cypress/02-template-project.md
@@ -1,5 +1,6 @@
 ---
 title: Template Project
+description: Ready-to-use Cypress template project for Wopee.io visual testing. Clone, configure your API key, and run your first visual test in minutes.
 ---
 
 This is anThis might be a good place to start with Wopee.io and Cypress visual testing. Our template project provides you with a ready-to-use setup for visual testing with Cypress and Wopee.io. Also you will find a demo test that you can run to see how it works.

--- a/docs/cypress/03-install-plugin.md
+++ b/docs/cypress/03-install-plugin.md
@@ -1,5 +1,6 @@
 ---
 title: Install Plugin
+description: Install the Wopee.io Cypress plugin to add visual regression testing to your existing Cypress project. Step-by-step setup guide.
 ---
 
 To start visual testing with your existing Cypress tests, leverage the benefits of the Wopee.io Cypress plugin. Follow the steps below to install the plugin.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,3 +1,7 @@
+---
+description: Definitions of key Wopee.io concepts including baselines, projects, branches, test runs, scenarios, steps, and comparison modes.
+---
+
 # 📖 Glossary
 
 ### Baseline

--- a/docs/guides/browser-local-storage.md
+++ b/docs/guides/browser-local-storage.md
@@ -1,3 +1,7 @@
+---
+description: Configure and upload browser local storage data for Wopee.io tests. Ensure tests run with the correct application state and user preferences.
+---
+
 # 🗄️ Browser local storage
 
 Configure and upload browser local storage data to ensure your tests run with the necessary application state and user preferences.

--- a/docs/guides/download-files.md
+++ b/docs/guides/download-files.md
@@ -1,3 +1,7 @@
+---
+description: Test file download functionality in your web app with Wopee.io. Verify downloads work correctly across browsers and file types.
+---
+
 # 📥 Download files
 
 Test your web application's file download functionality to ensure users can successfully download files, reports, and other content.

--- a/docs/guides/http-tools.md
+++ b/docs/guides/http-tools.md
@@ -1,3 +1,7 @@
+---
+description: Combine UI and API testing in one flow with the Wopee.io HTTP Request Tool. Trigger API calls directly within your web tests.
+---
+
 # 🔌 HTTP Request Tool
 
 Blend UI and API testing in one seamless flow with the new HTTP Request Tool. Trigger API calls directly within your web tests without context switching or additional setup.

--- a/docs/guides/project-context.md
+++ b/docs/guides/project-context.md
@@ -1,3 +1,7 @@
+---
+description: Set global instructions and context for Wopee.io AI testing agents. Guide agent behavior across all tests in your project.
+---
+
 # 🌍 Project context
 
 Configure global instructions and context that guide the AI testing agent's behavior across all tests in your project.

--- a/docs/guides/upload-files.md
+++ b/docs/guides/upload-files.md
@@ -1,3 +1,7 @@
+---
+description: Upload files to Wopee.io for testing file upload workflows. Support for images, documents, and other file types in your web app tests.
+---
+
 # 📁 Upload files
 
 Upload files to your testing environment to ensure your tests can interact with file upload functionality in your web application.

--- a/docs/guides/wopee-mcp.md
+++ b/docs/guides/wopee-mcp.md
@@ -1,3 +1,7 @@
+---
+description: Wopee.io MCP server for IDE integration. Manage test suites, generate test cases, and dispatch AI testing agents via Model Context Protocol.
+---
+
 # 🚀 Wopee.io MCP
 
 A Model Context Protocol (MCP) server for integrating with Wopee.io's autonomous testing platform. Manage analysis suites, generate test cases and user stories, and dispatch autonomous testing agents directly from your IDE.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 title: AI Testing Agents for your web apps
+description: Wopee.io AI testing agents explore your web app, generate Playwright tests, and self-heal when your UI changes. No coding required, deterministic test output.
 ---
 
 # AI Testing Agents for your web apps

--- a/docs/pilot-projects.md
+++ b/docs/pilot-projects.md
@@ -1,3 +1,7 @@
+---
+description: 8-week guided pilot projects with Wopee.io. Achieve 70-90% faster test creation, 2-5x coverage increase, and expert coaching for autonomous testing.
+---
+
 # Pilot Projects
 
 ## Why Choose a Pilot Project?

--- a/docs/playwright-visual-testing.md
+++ b/docs/playwright-visual-testing.md
@@ -1,3 +1,7 @@
+---
+description: Integrate Wopee.io visual testing with Playwright. Add visual validation to your existing tests in JavaScript, Python, Java, or .NET.
+---
+
 # Playwright
 
 ## 📄 About

--- a/docs/robot-framework/01-getting-started.md
+++ b/docs/robot-framework/01-getting-started.md
@@ -1,5 +1,6 @@
 ---
 title: Overview
+description: Get started with Wopee.io visual testing for Robot Framework. Works with Browser library, Selenium, and picture comparison for PDF or mobile apps.
 ---
 
 ## Getting started

--- a/docs/robot-framework/02-manual-setup.md
+++ b/docs/robot-framework/02-manual-setup.md
@@ -1,5 +1,6 @@
 ---
 title: Template project
+description: Manual setup guide for the Wopee.io Robot Framework template project. Install dependencies, configure API access, and run visual tests.
 ---
 
 The following steps will guide you through the setup of the template project. If you want a faster alternative, you can use the [Makefile](03-setup-with-make.md) to automate the setup process. However, following the instructions below will give you a better understanding of the project structure.

--- a/docs/robot-framework/03-setup-with-make.md
+++ b/docs/robot-framework/03-setup-with-make.md
@@ -1,5 +1,6 @@
 ---
 title: Setup with Make
+description: Automate Wopee.io Robot Framework setup with Makefile. Run visual tests with a single command after initial environment configuration.
 ---
 
 This makes some steps easier to run. You can use the Makefile to run tests with a single command.

--- a/docs/robot-framework/04-some-more-examples.md
+++ b/docs/robot-framework/04-some-more-examples.md
@@ -1,5 +1,6 @@
 ---
 title: Some more examples
+description: Advanced Wopee.io Robot Framework examples. Extract comparison details, handle multiple viewports, and integrate visual checks into CI pipelines.
 ---
 
 ## Comparison details from response

--- a/docs/security/enterprise-connectivity.md
+++ b/docs/security/enterprise-connectivity.md
@@ -1,3 +1,7 @@
+---
+description: Connect Wopee.io to apps behind VPN or firewalls. Options include IP allowlisting, VPN tunnels, and on-premise agent deployment.
+---
+
 # Enterprise Connectivity
 
 Connect Wopee.io to applications behind VPN, firewalls, or in secure enterprise environments.

--- a/docs/webdriverio-visual-testing.md
+++ b/docs/webdriverio-visual-testing.md
@@ -1,3 +1,7 @@
+---
+description: Set up Wopee.io visual testing with WebdriverIO. Clone the template project or install the plugin into your existing WebdriverIO setup.
+---
+
 # WebdriverIO
 
 ## Getting started


### PR DESCRIPTION
## Summary

- Add `description:` frontmatter to all 25 pages on docs.wopee.io
- MkDocs auto-generates `<meta name="description">`, `og:description`, and `og:title` from frontmatter
- Fixes 25 "missing meta description" and 25 "missing OG tags" warnings from Ahrefs Site Audit

## Pages updated

**Main:** index, ai-agent, glossary, pilot-projects
**Concepts:** analysis-inputs, analysis-process, pom-login-example, prompting-guidelines, tools-and-assertions
**Guides:** browser-local-storage, download-files, http-tools, project-context, upload-files, wopee-mcp
**Cypress:** overview, template-project, install-plugin
**Robot Framework:** overview, template-project, setup-with-make, more-examples
**Integrations:** playwright, webdriverio
**Security:** enterprise-connectivity

Closes marcel-veselka/vem-agents#139

## Test plan

- [ ] Verify meta descriptions render in page source (`<meta name="description" content="...">`)
- [ ] Check OG tags present (`og:title`, `og:description`)